### PR TITLE
Add/update PrideToken with logo URI

### DIFF
--- a/src/mainnet.tokens.json
+++ b/src/mainnet.tokens.json
@@ -1,6 +1,13 @@
 [
+
   {
-    "address": "0x71e26d0E519D14591b9dE9a0fE9513A398101490",
+  "address": "0xAE62Ca7e7Bc80C800DADc1c4b9175800033537cd",
+  "name": "PrideToken",
+  "symbol": "PRD",
+  "decimals": 18,
+  "logoURI": "https://pridefunding.org/assets/PrideToken/PrideTokenbg.svg"
+  },
+  {"address": "0x71e26d0E519D14591b9dE9a0fE9513A398101490",
     "name": "Ubeswap",
     "symbol": "UBE"
   },


### PR DESCRIPTION
This pull request adds the PrideToken (PRD) details to the `mainnet.tokens.json` file including the logo URI. It also updates the README with information about PrideToken and our crowdfunding platform for the LGBTQ+ community.

## Token Information
- **Name:** PrideToken
- **Symbol:** PRD
- **Contract Address:** `0xAE62Ca7e7Bc80C800DADc1c4b9175800033537cd`
- **Decimals:** 18
- **Chain:** Celo (Mainnet)
- **Logo:** [PrideToken Logo](https://pridefunding.org/assets/PrideToken/PrideTokenbg.svg)

## Crowdfunding Platform
We have established a crowdfunding platform for LGBTQ+ users to raise funds for various causes and projects. Users can initiate crowdfunding campaigns and receive funds in PrideToken (PRD). Donors are also encouraged to contribute using PrideToken, fostering a supportive economic ecosystem.
